### PR TITLE
Create index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>SparXSS</title>
+  </head>
+  <body>
+    <script src="sparxss.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
SparkVue's recent update blocks `<img>` tags, which was previously used to deploy the XSS payload. However, you can still link to HTTP and HTTPS webpages. This pull request adds an `index.html` file which simply executes the JavaScript payload, so that people can click that link to overwrite the SparkVue window.